### PR TITLE
Bitmex: invalid time-zone

### DIFF
--- a/src/Exchanges/BitMEX.ts
+++ b/src/Exchanges/BitMEX.ts
@@ -323,8 +323,8 @@ export default class BitMEX extends AbstractContractExchange {
             let importNext = () => {
                 let outParams = {
                     symbol: marketPair,
-                    startTime: utils.getUnixTimeStr(true, start),
-                    endTime: utils.getUnixTimeStr(true, end),
+                    startTime: utils.getUnixTimeStr(true, start, true),
+                    endTime: utils.getUnixTimeStr(true, end, true),
                     count: count, // note 500 is max, 100 is default
                     start: offset
                 }


### PR DESCRIPTION
You need to force `utils.getUnixTimeStr` to output in UTC timezone and not the local one (otherwise the data doesn't match)