### PR TITLE
Uniqueness issue at tradeID / uniqueID on bitmex

### DIFF
--- a/src/Exchanges/BitMEX.ts
+++ b/src/Exchanges/BitMEX.ts
@@ -337,7 +337,8 @@ export default class BitMEX extends AbstractContractExchange {
                         // NB: {rawTrade.homeNotional} as well as {rawTrade.grossValue}/10e8 would be equiv. to {size} div. by {price} besides some nasty rounding errors
                         tradeObj.amount = Math.abs(rawTrade.size / rawTrade.price); // Unit: Home (e.g. USD)
                         tradeObj.rate = rawTrade.price;
-                        tradeObj.tradeID = Math.floor(tradeObj.date.getTime() * tradeObj.amount)
+                        let tradeHash = crypto.createHash('sha1').update(rawTrade.trdMatchID).digest('hex'); // Original: 128bit hex-ID
+                        tradeObj.tradeID = parseInt(tradeHash.slice(0, 13), 16); //JS's number type has at most an 53bit integer-part thus a 13.25 digit hex-number could at max fit into 53bits.
                         tradeObj = Trade.Trade.verifyNewTrade(tradeObj, currencyPair, this.getExchangeLabel(), this.getFee())
 
                         trades.push(tradeObj)


### PR DESCRIPTION
Hi again, the `tradeID` and so the `uniqueID` have the potential of being non-unique which I already backed-up with real-data occurrences (for me it doesn't seem that uncommon).

A much better approach would be to use the built-in `trdMatchID` of Bitmex squeezed into a JS-number type. Do you've got an idea on how to conduct it elegantly? My workaround would be to hash the original id and then slice it for a proper fit into the very 53-bit integer-part of an JS number.