### PR TITLE
update BitMEX balance API

### DIFF
--- a/src/Exchanges/BitMEX.ts
+++ b/src/Exchanges/BitMEX.ts
@@ -257,12 +257,12 @@ export default class BitMEX extends AbstractContractExchange {
             let params = {
                 currency: "XBt" // BitMEX wallet only holds XBT
             }
-            this.privateReq("GET /user/wallet", params).then((balance) => { // instead of /walletSummary
+            this.privateReq("GET /user/margin", params).then((balance) => { // instead of /walletSummary
                 //console.log(balance)
                 if (!balance || balance.error)
                     return reject({txt: "Error getting bitmex balance", err: balance});
                 let balances = {}
-                balances["BTC"] = BitMEX.satoshi2BTC(balance.amount);
+                balances["BTC"] = BitMEX.satoshi2BTC(balance.walletBalance);
 
                 resolve(Currency.fromExchangeList(balances, this.currencies))
             }).catch((err) => {


### PR DESCRIPTION
Update to https://www.bitmex.com/api/explorer/#!/User/User_getMargin
`/user/wallet` only provides balance information (from deposits/withdraws) but not realized PNLs. `/user/margin` provides data that is displayed to user frontend for wallet balance (which includes realized PNLs), margin balance (which includes unrealized PNLs), etc