### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+mongodb

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ public/js/libs/tv
 
 # to prevent uploading local/private module dependencies
 package.json
+
+#docker mongodb
+mongodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,27 +17,19 @@ COPY . .
 RUN yarn install
 
 WORKDIR /app/node_modules/@ekliptor/apputils
-#Disable Typescript watch mode
-RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
 #Needs a exit 0 because of build errors
-RUN tsc; exit 0
+RUN tsc --watch false; exit 0
 
 WORKDIR /app/node_modules/@ekliptor/bit-models
-#Disable Typescript watch mode
-RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
 #Needs a exit 0 because of build errors
-RUN tsc; exit 0
+RUN tsc --watch false; exit 0
 
 WORKDIR /app/node_modules/@ekliptor/browserutils
-#Disable Typescript watch mode
-RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
-RUN tsc
+RUN tsc --watch false
 
 WORKDIR /app
 
-#Disable Typescript watch mode
-RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
-RUN tsc; exit 0
+RUN tsc --watch false; exit 0
 
 RUN chown -R node:node /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:12-slim
+
+RUN set -x && \
+  apt-get update && \
+  apt-get install -y \
+          build-essential \
+          make \
+          python
+
+#Install Typescript
+RUN npm install typescript@3.6.5 -g
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY . .
+RUN yarn install
+
+WORKDIR /app/node_modules/@ekliptor/apputils
+#Disable Typescript watch mode
+RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
+#Needs a exit 0 because of build errors
+RUN tsc; exit 0
+
+WORKDIR /app/node_modules/@ekliptor/bit-models
+#Disable Typescript watch mode
+RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
+#Needs a exit 0 because of build errors
+RUN tsc; exit 0
+
+WORKDIR /app/node_modules/@ekliptor/browserutils
+#Disable Typescript watch mode
+RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
+RUN tsc
+
+WORKDIR /app
+
+#Disable Typescript watch mode
+RUN sed -i '/^[[:space:]]*"watch":/ s/:.*/: false/' tsconfig.json
+RUN tsc; exit 0
+
+RUN chown -R node:node /app
+
+USER node
+
+WORKDIR /app/build
+
+CMD [ "node", "app.js", "--debug", "--config=Noop" ,"--trader=RealTimeTrader" ,"--noUpdate" ,"--noBrowser" ]

--- a/configLocal-Docker.ts
+++ b/configLocal-Docker.ts
@@ -1,0 +1,265 @@
+// exported keys in here must be exactly the same as they are written on nconf object (except "root")
+
+import {Currency} from "@ekliptor/bit-models";
+import {nconf} from "@ekliptor/apputils";
+
+const root = {
+    "apiKeys" : { // leeave empty to disable API keys (public access)
+        "IWasTooLazyToChangeThis": true // set to false to disable a key
+    },
+    "updateUrl": "",
+    // put your MongoDB connection URL in here: mongodb://user:password@host:port/database
+    "mongoUrl": "mongodb://mongodb:27017/wolfbot",
+    "searchHosts": [], // elasticsearch host:port - currently not used
+
+    // proxy config. only needed if the exchange you want to trade on isn't accessible from your IP
+    "proxy": "", // http://user:password@host:port
+    "proxyAuth" : "", // http://user:password@DOMAIN:port <- domain is a constant replaced by the app
+    "ipCheckUrl" : "" // a URL returning JSON: {ip: "my.ip"}
+}
+
+const DEFAULT_MARGIN_NOTIFICATION = 0.26
+const DEFAULT_EXCHANGE_PROXY = [] // an array of proxy strings. chosen randomly
+
+class ServerConfig {
+    // place any config from bit-models/serverConfig.ts in here to overwrite it with app-specific values
+
+    //public notificationMethod = "NoNotificationService" // name of the notification class ("Pushover") // use value from config.json
+    public adminNotificationMethod = "NoNotificationService"
+
+    // place all keys here. we don't run user specific configurations to keep the design simpler. each user has his own bot instance
+    public apiKey = {
+        // a class with the exact same name has to exist under /Exchanges/ resp /Notifications/
+        exchange: {
+            // remove an exchange here to disable trading on it
+            // marginNotification,proxy are optional. leave empty to disable it
+            Poloniex: [{
+                key: "",
+                secret: "",
+                marginNotification: DEFAULT_MARGIN_NOTIFICATION
+            }],
+            OKEX: [{
+                key: "",
+                secret: "",
+                passphrase: "",
+                marginNotification: 0.03,
+                proxy: DEFAULT_EXCHANGE_PROXY
+            }],
+            Kraken: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.75
+            }],
+            // we need to 2 keys per array entry on bitfinex because we use API v2 and v1 currently
+            Bitfinex: [{
+                key: "",
+                secret: "",
+                key2: "",
+                secret2: "",
+                marginNotification: 0.22 // min margin 0.13
+            }],
+            Bittrex: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Binance: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            BinanceUS: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            BitMEX: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.03,
+                testnet: false
+            }],
+            Deribit: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.03,
+                testnet: false
+            }],
+            CoinbasePro: [{
+                key: "",
+                secret: "",
+                passphrase: "",
+                marginNotification: 0.5
+            }],
+            Bitstamp: [{
+                key: "",
+                secret: "",
+                passphrase: "",
+                marginNotification: 0.5
+            }],
+            CexIo: [{
+                key: "",
+                secret: "",
+                passphrase: "",
+                marginNotification: 0.5
+            }],
+            Cobinhood: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Gemini: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            HitBTC: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Huobi: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            KuCoin: [{
+                key: "",
+                secret: "",
+                passphrase: "",
+                marginNotification: 0.5
+            }],
+            Nova: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            BitForex: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            FCoin: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Bibox: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            BinanceFutures: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            KrakenFutures: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            BxCo: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Liquid: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            YoBit: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Coss: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Bybit: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Bitkub: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            TheRockTrading: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            FTX: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+            Peatio: [{
+                key: "",
+                secret: "",
+                domain: "",
+                marginNotification: 0.5
+            }],
+            LoggerEx: [{
+                key: "",
+                secret: "",
+                marginNotification: 0.5
+            }],
+        },
+        notify: {
+            Pushover: {
+                appToken: "",
+                receiver: ""
+            },
+            Telegram: {
+                receiver: "",
+                channel: "",
+                serverPort: 5142
+            }
+        }
+    }
+
+    public twitterApi = {
+        consumerKey: '',
+        consumerSecret: '',
+        // we can get additional queries by removing this (limit per app instead of per user)
+        accessTokenKey: '',
+        accessTokenSecret: ''
+    }
+
+    public backtest = {
+        from: "2017-08-01 00:00:00",
+        to: "2017-09-04 00:00:00",
+
+        startBalance: 1.0, // for every coin (leveraged *2.5 when margin trading)
+        slippage: 0.0, // in %, for example 0.05%
+        cacheCandles: false,
+        walk: true, // Walk Forward Analysis: load previously optimized parameters and continue optimizing on them
+        resetWarmupBacktestErrorSec: 30,
+        timeOffsetMin: 0
+    }
+}
+
+// premium config
+let orverrides = () => {
+}
+
+const serverConfig = new ServerConfig();
+let tradingViewAccount = {
+    email: "",
+    password: ""
+}
+
+export {root, serverConfig, orverrides, tradingViewAccount}
+
+
+export type MultipleCurrencyImportExchange = "Poloniex" | "Bitfinex" | "BitMEX";
+export const currencyImportMap = new Map<MultipleCurrencyImportExchange, Currency.CurrencyPair[]>([
+]);
+export const liveTradeImportMap = new Map<MultipleCurrencyImportExchange, Currency.CurrencyPair[]>([
+]);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - mongodb
   mongodb:
     image: mongo:latest
-    container_name: "mongodb"
     environment:
       - MONGO_DATA_DIR=/data/db
       - MONGO_LOG_DIR=/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  wolfbot:
+    build: .
+    image: wolfbot-docker/latest
+    restart: always
+    ports:
+      - "8331:8331"
+      - "8332:8332"
+    depends_on:
+      - mongodb
+  mongodb:
+    image: mongo:latest
+    container_name: "mongodb"
+    environment:
+      - MONGO_DATA_DIR=/data/db
+      - MONGO_LOG_DIR=/dev/null
+    volumes:
+      - ./mongodb/data/db:/data/db


### PR DESCRIPTION
I've created a simple docker-compose setup that will bring up WolfBot with MongoDB & the default configuration.
All you have to do before is copy/rename the file configLocal-Docker.ts to configLocal.ts - and adjust it according to your needs (API etc.). The MongoDB URl is correct! It is just referencing the container internal name.

After a "docker-compose up" you should be able to reach your WolfBot at http://your.docker.host:8331/index.html?apiKey=SomeAPIkey

There are some dirty hacks in the Dockerfile to get this working (disabling Typescript watch mode, forcing clean exit codes although Typescript reports errors). To be able to clear these, the main maintainer would have to clean up the code a bit more :)